### PR TITLE
add support for limit and offset parameters

### DIFF
--- a/src/repositories/clientInvoicesRepoAggregate.ts
+++ b/src/repositories/clientInvoicesRepoAggregate.ts
@@ -39,7 +39,7 @@ export type ClientListingFilterByArgs = {
 
 export class ClientInvoicesRepoAggregate {
     private static _instance: ClientInvoicesRepoAggregate;
-    
+
     static async getInstance () {
         if (!ClientInvoicesRepoAggregate._instance) {
             ClientInvoicesRepoAggregate._instance = new ClientInvoicesRepoAggregate();
@@ -54,7 +54,7 @@ export class ClientInvoicesRepoAggregate {
 
     async getInvoices(params: {userId:string, filter?: InvoiceListingFilterByArgs, sort?: InvoiceListingSortingByArgs, offset?: number, limit?: number}) {
         const { filter = {}, sort = {}, userId, offset = 0, limit = 20 } = params;
-        
+
         const allInvoices = this.invoicesRepo.getByUserId(userId)
         const allResults: InvoiceWithClientDetails[] = [];
         for ( let i = 0; i < allInvoices.length; i += 1 ) {
@@ -87,7 +87,7 @@ export class ClientInvoicesRepoAggregate {
                     return item.invoice.dueDate >= startDate && item.invoice.dueDate < endDate;
                 })
             }
-           
+
         }
 
         let sortedResults = filteredResults;
@@ -97,7 +97,7 @@ export class ClientInvoicesRepoAggregate {
                 sortedResults = sortedResults.sort((a,b) => {
                     if ( a.invoice.date > b.invoice.date ) {
                         return coef;
-                    } 
+                    }
                     return -coef;
                 });
             }
@@ -107,7 +107,7 @@ export class ClientInvoicesRepoAggregate {
                 sortedResults = sortedResults.sort((a,b) => {
                     if ( a.invoice.dueDate > b.invoice.dueDate ) {
                         return coef;
-                    } 
+                    }
                     return -coef;
                 });
             }
@@ -117,7 +117,7 @@ export class ClientInvoicesRepoAggregate {
                 sortedResults = sortedResults.sort((a, b) => {
                     if ( a.client.companyDetails.name > b.client.companyDetails.name ) {
                         return coef;
-                    } 
+                    }
                     return -coef;
                 })
             }
@@ -127,13 +127,12 @@ export class ClientInvoicesRepoAggregate {
                 sortedResults = sortedResults.sort((a, b) => {
                     if ( a.invoice.value > b.invoice.value ) {
                         return coef;
-                    } 
+                    }
                     return -coef;
                 })
             }
         }
-
-        return sortedResults;
+        return sortedResults.slice(offset, limit);
     }
 
 
@@ -161,7 +160,7 @@ export class ClientInvoicesRepoAggregate {
                 sortedResults = sortedResults.sort((a,b) => {
                     if ( a.name > b.name ) {
                         return coef;
-                    } 
+                    }
                     return -coef;
                 });
             }
@@ -171,7 +170,7 @@ export class ClientInvoicesRepoAggregate {
                 sortedResults = sortedResults.sort((a, b) => {
                     if ( a.companyDetails.name > b.companyDetails.name ) {
                         return coef;
-                    } 
+                    }
                     return -coef;
                 })
             }
@@ -181,18 +180,17 @@ export class ClientInvoicesRepoAggregate {
                 sortedResults = sortedResults.sort((a, b) => {
                     if ( a.totalBilled > b.totalBilled ) {
                         return coef;
-                    } 
+                    }
                     return -coef;
                 })
             }
         }
-
-        return sortedResults;
+        return sortedResults.slice(offset, limit);
     }
 
 
     async addInvoice (params: { user_id: string, invoiceData: Partial<InvoiceData> } ) {
-        const { 
+        const {
             invoice_number,
             client_id,
             date,
@@ -202,7 +200,7 @@ export class ClientInvoicesRepoAggregate {
             meta = {}
          } = params.invoiceData
 
-         if ( 
+         if (
             !(invoice_number && client_id && date && value)
          ) {
             throw new Error("Invalid invoice payload. Need invoice_number && client_id && date && value")

--- a/src/routes/main.ts
+++ b/src/routes/main.ts
@@ -8,17 +8,16 @@ import { UsersRepository } from '../repositories/usersRepository'
 export const mainRoutes = (app: Express ) => {
 
     app.get("/invoices", verifyTokenMiddleware, async (req, res) => {
-        
         try {
             const { params = "{}" } = req.query as Record<string, any>;
             const queryParams = JSON.parse(params)
-    
-            const { filter, sort } = queryParams
+
+            const { filter, sort, offset, limit } = queryParams
 
             const invoiceAggregate = app.get("invoiceClientAggregate") as ClientInvoicesRepoAggregate
             const userId = (req as any).user.user_id;
             const result = await invoiceAggregate.getInvoices({
-                userId, filter, sort
+                userId, filter, sort, offset, limit
             })
             return res.json({invoices: result})
         } catch (err) {
@@ -61,15 +60,15 @@ export const mainRoutes = (app: Express ) => {
             const invoicesRepo = app.get("invoicesRepo") as InvoicesRepository
             const userId = (req as any).user.user_id as string;
             const invoiceData = await invoicesRepo.getById(req.body.id)
-            
+
             if ( !invoiceData ) {
                 res.status(404).send("Client not found. Cannot update.")
             }
-            
+
             if ( invoiceData.user_id !== userId ) {
                 res.status(404).send("Client not found. Cannot update.")
             }
-            
+
             const result = await invoicesRepo.update({user_id: userId, ...req.body})
             return res.json({success: true, invoice: result})
            } catch (err) {
@@ -79,21 +78,19 @@ export const mainRoutes = (app: Express ) => {
 
     app.get("/clients", verifyTokenMiddleware, async (req, res) => {
         const invoiceAggregate = app.get("invoiceClientAggregate") as ClientInvoicesRepoAggregate
-       
         try {
             const { params = "{}" } = req.query as Record<string, any>;
             const queryParams = JSON.parse(params)
-    
-            const { filter, sort } = queryParams
-            
+            const { filter, sort, offset, limit } = queryParams
+
             const userId = (req as any).user.user_id;
             const result = await invoiceAggregate.getClients({
-                userId, filter, sort
+                userId, filter, sort, offset, limit
             })
             setTimeout(() => {
                 res.json({clients: result})
             }, 1000)
-            return 
+            return
         } catch (err) {
             console.log(err.message);
             res.status(500).send(err.message)
@@ -132,15 +129,15 @@ export const mainRoutes = (app: Express ) => {
             const clientsRepo = app.get("clientsRepo") as ClientsRepository
             const userId = (req as any).user.user_id as string;
             const userOwningClient = await clientsRepo.getById(req.body.id)
-            
+
             if ( !userOwningClient ) {
                 res.status(404).send("Client not found. Cannot update.")
             }
-            
+
             if ( userOwningClient.user_id !== userId ) {
                 res.status(404).send("Client not found. Cannot update.")
             }
-            
+
             const result = await clientsRepo.update({user_id: userId, ...req.body})
             return res.json({success: true, client: result})
            } catch (err) {


### PR DESCRIPTION
I have added `limit` and `offset` to the `queryParams` of `/invoices` and `/clients` and implemented this via a simple slice for now. For pagination this is still not really ideal, since you will not know ahead of time how many results/ pages to expect overall or at least if there is a "next page".