### PR TITLE
Filter clients with totals and number of invoices by id

### DIFF
--- a/src/repositories/clientInvoicesRepoAggregate.ts
+++ b/src/repositories/clientInvoicesRepoAggregate.ts
@@ -158,7 +158,16 @@ export class ClientInvoicesRepoAggregate {
             }
         })
 
-        let sortedResults = allClientsWithTotalBilledAndNumberOfInvoices;
+        let filteredResults = allClientsWithTotalBilledAndNumberOfInvoices;
+        if ( Object.keys(filter).length ) {
+            if ( filter.clientId ) {
+                filteredResults = filteredResults.filter((item) => {
+                    return item.id === filter.clientId
+                })
+            }
+        }
+
+        let sortedResults = filteredResults;
         if ( Object.keys(sort).length ) {
             if ( sort.clientName ) {
                 const coef = sort.clientName === 'asc' ? 1 : -1


### PR DESCRIPTION
currently it is not possible to obtain a single client with the totalization columns. add this so that we can request a single client e.g. to load a single client on the client view page.