### PR TITLE
npm start to run all required action

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "npx tsc",
-    "start": "node .",
+    "start": "npm run build && DEBUG_GRAPH_QL=true node .",
     "test": "cross-env ENVIRONMENT=test jest",
     "reset-dev-db": "cross-env PATH_TO_JSON_DIR=./fake-database node ./scripts/reset-dev-db"
   },


### PR DESCRIPTION
Most of the time I (may be all) forgot this long command `npm run build && DEBUG_GRAPH_QL=true npm run start` 
So I guess put everything in `npm start` is easy to use.